### PR TITLE
Prevent crashes that happen if players have non-ASCII characters in their names when using the 'Load players' and 'Export Pods/Standings' functionalities on Windows machines by setting the appropriate encoding when opening and writing the files (`encoding='utf-8'`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 .qt_for_python
 .vscode
 .vscode/*
+.idea
 print.txt
 players.txt
 venv/*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The software was developed on Linux and installation should be rather straight f
 ### Windows ###
 
 First, you need python 3 and pip working.
-The easiest way to do this on Windows is by downloading the latest python version from official site (an installer). Generally, following default steps is OK, but you have to change one thing:
+The easiest way to do this on Windows is by downloading the latest python version from [official site](https://www.python.org/downloads/) (an installer). Generally, following default steps is OK, but you have to change one thing:
 
 **Important:** When installing, you have a couple of checkboxes. The one you want to tick is the "Add python to PATH" (or something similar).
 
@@ -27,6 +27,8 @@ To make sure it's added, go to your start menu, and search for "Edit the system 
 Once you find it, depending on the version of Windows you have, you will have different sections. Search for "Path" variable and check if your python installation dirrectory is also added. Since this is not really the scope of this installation guide, you will have to figure this on your own as it can differ a bit from system to system, but generally something along those lines.
 
 Right, now that you've checked that python is actually in your Path variable, it's still possible that python is not recognized. Windows 10 can hide it behind some *feature*. I'll try to find what it was, but I think it was something along system integration of python or something. To be added.
+
+Rebooting your system might help the machine recognize python and pip if you're sure they're in your Path variable (especially on older versions of Windows).
 
 ### Once python is sorted, the actual installation
 

--- a/run_ui.py
+++ b/run_ui.py
@@ -121,7 +121,7 @@ class MainWindow(QMainWindow):
             initialFilter='*.txt',
         )
         if file:
-            with open(file, 'r') as f:
+            with open(file, 'r', encoding='utf-8') as f:
                 player_names = f.readlines()
             self.core.add_player([p.strip() for p in player_names])
             self.restore_ui()

--- a/run_ui.py
+++ b/run_ui.py
@@ -71,6 +71,8 @@ class MainWindow(QMainWindow):
         QMainWindow.__init__(self)
         self.core = core if core else Tournament()
 
+        self.setWindowTitle("EDH matchmaker")
+
         # Window code
         self.ui = uic.loadUi('./ui/MainWindow.ui')
         self.setCentralWidget(self.ui)

--- a/src/core.py
+++ b/src/core.py
@@ -573,7 +573,7 @@ class Tournament:
             Log.log('No pods currently created.')
 
     def export_str(self, fdir, str):
-        with open(fdir, 'w') as f:
+        with open(fdir, 'w', encoding='utf-8') as f:
             f.writelines(str)
 
     def get_standings(self) -> list[Player]:


### PR DESCRIPTION
* Update: Add additional help in readme for adding python to Path in Windows and a link to python downloads page
* Update: Add `.idea` to `.gitignore`
* Update: Set main window title