### PR TITLE
Use monospaced font

### DIFF
--- a/run_ui.py
+++ b/run_ui.py
@@ -1005,6 +1005,14 @@ if __name__ == '__main__':
 
     app = QApplication(sys.argv)
 
+    # Define a monospaced font
+    monospace_font = QFont("Courier New")  # Common monospaced font
+    monospace_font.setStyleHint(QFont.StyleHint.Monospace)  # Ensure it's monospaced
+    monospace_font.setPointSize(12)  # Set font size
+
+    # Apply the font globally
+    app.setFont(monospace_font)
+
     if args.open:
         TournamentAction.load(args.open)
         core = TournamentAction.ACTIONS[-1].after


### PR DESCRIPTION
I noticed commented out code for monospaced font usage. What gives?
I'd argue for it, to take advantage of using `ljust` and ensure proper "ASCII art/tables" alignment...
If done in the suggested way, all fonts in the app are adjusted, which might be overkill, and some windows might also need some tinkering with size to ensure proper visibility of all GUI elements.
Could be done on a per-widget basis, perhaps only for the text-fields?